### PR TITLE
Pull the `Map` and `Spec` libraries from their repos.

### DIFF
--- a/manifest.savi
+++ b/manifest.savi
@@ -6,6 +6,8 @@
   :sources "spec/*.savi"
 
   :dependency Spec v0
+    :from "github:savi-lang/Spec"
     :depends on Map
 
   :transitive dependency Map v0
+    :from "github:savi-lang/Map"


### PR DESCRIPTION
Using no `:from` clause on a dependency is deprecated,
and all standard library packages are moving to their own repos.