### PR TITLE
Fix _SimpleVM.continue! to have an explicit error type.

### DIFF
--- a/src/_SimpleVM.savi
+++ b/src/_SimpleVM.savi
@@ -89,6 +89,7 @@
     @did_match
 
   :fun ref _continue!(threads Array(USize), address USize)
+    :errors None
     // TODO: prevent creating a new thread with gen == gen trick
 
     // Here we handle control flow opcodes that consume no input.


### PR DESCRIPTION
Prior to this commit, the library wasn't compiling with the latest version of Savi because latest Savi allows for error values with a designated type, but this function was self-recursive and thus couldn't confidently infer the error type.

This commit resolves the ambiguity by adding `:errors None`.